### PR TITLE
docs: JS正则 W3C标准视角整理

### DIFF
--- a/docs/js/regex-in-browser.md
+++ b/docs/js/regex-in-browser.md
@@ -1,0 +1,470 @@
+---
+title: JavaScript 正则表达式 — W3C 标准视角
+description: 从浏览器实现、ECMAScript 规范角度深入理解 JavaScript RegExp，涵盖 Symbol 方法、Unicode 模式、lastIndex 机制与实际应用
+tags: javascript regexp ecmascript w3c browser
+specRefs:
+  - https://tc39.es/ecma262/#sec-regexp-regular-expression-objects
+  - https://tc39.es/ecma262/#sec-string.prototype.match
+  - https://tc39.es/ecma262/#sec-regexp.prototype-@@match
+  - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp
+caniuseRefs:
+  - https://caniuse.com/mdn-javascript_builtins_regexp_lastindex
+  - https://caniuse.com/mdn-javascript_builtins_regexp_unicode
+  - https://caniuse.com/?search=named%20capture
+demoLinks:
+  - regex-in-browser/examples/index.html
+---
+
+# JavaScript 正则表达式 — W3C 标准视角
+
+> 本文从 ECMAScript 规范与浏览器实现角度梳理 JavaScript 正则表达式，区别于基础语法讲解，重点关注规范定义的内部机制、Symbol 方法协议以及与浏览器环境的交互。
+
+---
+
+## 1. RegExp 在 ECMAScript 规范中的定义
+
+### 1.1 规范结构
+
+ECMAScript 规范（[tc39.es/ecma262](https://tc39.es/ecma262)）将 RegExp 定义为**内置对象**，其行为由 `RegExp` 构造函数、`RegExp.prototype` 以及多个**内部槽（Internal Slots）** 决定。核心章节为 **"21.2 RegExp (Regular Expression) Objects"**。
+
+关键内部槽：
+
+| 内部槽 | 含义 |
+|---|---|
+| `[[OriginalSource]]` | 正则模式原始字符串（含斜杠分隔符外的全部内容） |
+| `[[OriginalFlags]]` | 原始 flags 字符串 |
+| `[[RegExpMatcher]]` | 执行匹配的内部算法实现 |
+| `[[LastIndex]]` | 上一次匹配结束的位置（用于 `g`/`y` flag） |
+| `[[Groups]]` | 具名捕获组元信息（ES2018+） |
+
+### 1.2 字面量语法解析
+
+```js
+/pattern/flags
+```
+
+字面量语法 `/.../` 由 **词法扫描器（Scanner）** 在解析 JavaScript 源码时处理：
+
+1. 遇到 `/` 后进入 **PatternToken** 状态
+2. 持续读取字符直到遇到匹配的结束 `/`
+3. 期间对 `\` 进行特殊处理（转义），但不解释正则元字符
+4. 结束后读取 flags（允许的字符：`d`, `g`, `i`, `m`, `s`, `u`, `v`, `y`）
+5. 构造 `RegExp` 对象，`[[OriginalSource]]` 保存原始模式字符串
+
+> **规范细节**：字面量解析发生在**语法分析阶段**，比构造函数 `new RegExp()` 的解析（运行时）更早，且不执行字符串转义。
+
+### 1.3 构造器 vs 字面量
+
+| | 字面量 `/pattern/flags` | `new RegExp(pattern, flags)` |
+|---|---|---|
+| 解析时机 | 编译时（源码扫描） | 运行时 |
+| `pattern` 类型 | 字面量源码字符 | 字符串 |
+| `\` 转义 | 不解释（保留原样） | 需双写 `\\` 转义 |
+| 相同模式对象 | 共享（规范要求共享字面量对象，浏览器通常复用） | 每次 `new` 创建新对象 |
+
+---
+
+## 2. String.prototype 与正则的交互（规范算法）
+
+ECMAScript 规范为每个 String 方法定义了与 RegExp 交互的**标准算法**，通过 **Well-Known Symbol** 触发内部方法。
+
+### 2.1 核心 Symbol 方法对应关系
+
+| Symbol 方法 | 触发来源 | 返回值 |
+|---|---|---|
+| `RegExp.prototype[@@match]` | `String.prototype.match()` | Array 或 `null` |
+| `RegExp.prototype[@@replace]` | `String.prototype.replace()` | 替换后字符串 |
+| `RegExp.prototype[@@search]` | `String.prototype.search()` | 匹配起始索引 |
+| `RegExp.prototype[@@split]` | `String.prototype.split()` | 分割后的字符串数组 |
+| `RegExp.prototype[@@matchAll]` | `String.prototype.matchAll()` | 可迭代的 Match 对象 |
+
+### 2.2 `String.prototype.match()` 算法（规范 §21.1.3.10）
+
+```text
+String.prototype.match(regexp)
+1. If regexp is undefined or null, return String(this) match against /\/*s*/.
+2. Let rx be ? ToObject(regexp).
+3. Let matcher be ? GetMethod(rx, @@match).
+4. Return ? matcher.call(rx, this).
+```
+
+关键点：
+- 如果传入的不是对象（或没有 `@@match` 方法），规范不会自动回退到正则字面量匹配
+- `@@match` 方法的存在本身作为**正则身份标识**：若 `@@match === undefined`（非正则对象），某些操作会抛出 `TypeError`
+
+### 2.3 `String.prototype.replace()` 与 `@@replace`
+
+`@@replace` 算法（规范 §21.1.3.17）核心流程：
+
+1. 从左到右执行所有匹配（`g` flag）
+2. 对每个匹配调用 **Replacer Algorithm**：解析 `$1`, `$<name>` 等替换占位符
+3. 捕获组结果通过 `MatchRecord` 传递
+
+```js
+// 具名捕获组在 replace 中的使用
+"2026-04-01".replace(/(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})/u, 
+  "$<day>/$<month>/$<year>"
+)
+// "01/04/2026"
+```
+
+---
+
+## 3. Unicode 模式（`u` flag）与 Code Point
+
+### 3.1 UTF-16 与 JavaScript 字符串
+
+JavaScript 字符串采用 **UTF-16 编码**：
+- Basic Multilingual Plane（BMP，U+0000–U+FFFF）：1 个代码单元 = 1 个代码点
+- 增补平面（Supplementary，U+10000+）：2 个代码单元（surrogate pair）
+
+```js
+"😄".length        // 2 — 是两个 UTF-16 代码单元
+[..."😄"].length   // 1 — 展开后是 1 个代码点
+```
+
+### 3.2 `u` flag 的规范效果
+
+启用 `u` flag 后，正则引擎行为发生根本变化：
+
+| 行为 | 无 `u` flag | 有 `u` flag |
+|---|---|---|
+| `.` 匹配粒度 | UTF-16 代码单元 | Unicode 代码点 |
+| `\u{xxxx}` 语法 | 语法错误 | 匹配代码点 U+xxxx |
+| `\p{...}` Unicode 属性 | 语法错误 | 匹配 Unicode 属性 |
+| 字符类范围 | 按代码单元排序 | 按代码点排序 |
+| 量词作用范围 | 1 个代码单元 | 1 个代码点 |
+
+```js
+// 无 u flag：超出 BMP 的字符被截断处理
+/./.test("😄")    // false — . 不匹配 0xD83D（surrogate half）
+
+// 有 u flag：正确匹配整个表情符号
+/./u.test("😄")   // true — . 匹配代码点 U+1F604
+```
+
+### 3.3 `\p{...}` Unicode 属性逃逸（ES2018+）
+
+需要 `u` flag 才能使用：
+
+```js
+// 匹配所有 Unicode 字母（含中文）
+/\p{L}/u.test("中")  // true
+/\p{L}/u.test("A")   // true
+
+// 匹配 Unicode 数字
+/\p{N}/u.test("５")   // true（全角数字）
+
+// 匹配 Emoji
+/\p{Emoji}/u.test("😄") // true
+
+// 匹配 Unicode 脚本（Script）
+/\p{Script=Han}/u.test("乐")  // true — 汉字
+/\p{Script=Latin}/u.test("a") // true
+```
+
+### 3.4 `v` flag（ES2024）
+
+`v` flag 是 `u` 的扩展，支持：
+- **集合操作**：`[[a-z]&&[m-p]]` 交集、`[[a-z]--[m-p]]` 差集
+- **字符串属性**：如 `\p{Script_Extensions=Hiragana}`
+
+```js
+// v flag 下可以使用字符串属性和集合操作
+/\p{RGI_Emoji_Set}/v.test("😄")  // true
+```
+
+> 注意：`u` 和 `v` 不能同时使用，会报 `SyntaxError`。
+
+---
+
+## 4. `lastIndex`、Sticky（`y`）与 Global（`g`）flag
+
+### 4.1 `lastIndex` 内部槽
+
+`lastIndex` 是 `RegExp.prototype` 的一个**可写属性**，映射到内部槽 `[[LastIndex]]`。它只在 `g` 或 `y` flag 存在时对匹配行为产生影响。
+
+### 4.2 `g` flag — 全局匹配
+
+`g` flag 下，`@@match`（对应 `String.prototype.match()`）会**循环调用** `RegExp.prototype.exec()`，直到返回 `null`：
+
+```js
+const re = /ab/g;
+re.lastIndex = 0;  // 初始化
+const str = "_ab_ab_";
+const matches = [];
+let result;
+while ((result = re.exec(str)) !== null) {
+  matches.push(result[0]);
+  // lastIndex 自动推进到上一次匹配结束位置
+}
+console.log(matches); // ["ab", "ab"]
+```
+
+**关键规范行为**：
+- `exec()` 成功 → `lastIndex` 设为 `matchEnd`
+- `exec()` 失败 → `lastIndex` 重置为 `0`
+- `match()` 调用 `@@match`，内部按同样逻辑处理
+
+### 4.3 `y` flag — Sticky（粘滞）匹配
+
+`y` flag 保证匹配**严格从 `lastIndex` 位置开始**，不向前扫描：
+
+```js
+const re = /ab/y;
+re.lastIndex = 1;
+re.test("_ab_")  // true — 从 index 1 开始匹配
+re.test("_ab_")  // false — lastIndex=3，但字符串[3]="_"，无法匹配"ab"
+```
+
+### 4.4 `g` 与 `y` 的组合
+
+规范规定：当 `g` 和 `y` 同时存在时，`exec()` 的行为**优先遵循 sticky 语义**（即只从 `lastIndex` 位置匹配，不循环）：
+
+```js
+const re = /ab/gy;
+re.lastIndex = 1;
+re.exec("_ab_ab_")  // null — index 1 是 "_"，不是 "ab" 的起点
+re.lastIndex = 3;
+re.exec("_ab_ab_")  // ["ab", index: 3] — 从 index 3 匹配
+```
+
+### 4.5 `lastIndex` 推进规则
+
+规范 §21.2.2.2（RegExpBuiltinExec）定义的推进规则：
+
+| 匹配结果 | `lastIndex` 行为 |
+|---|---|
+| 成功，非空匹配 | 推进到 `endIndex`（匹配内容末尾） |
+| 成功，空匹配 | `u` flag → 推进 1 个**代码点**；无 `u` → 推进 1 个**代码单元** |
+| 失败 | 重置为 `0` |
+
+---
+
+## 5. 具名捕获组（Named Capture Groups / NFE）
+
+### 5.1 规范背景
+
+ES2018 引入 **Named Capture Groups**，语法 `(?<name>pattern)`。结果对象通过 `groups` 属性访问：
+
+```js
+const re = /(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})/u;
+const result = re.exec("2026-04-01");
+result.groups        // { year: "2026", month: "04", day: "01" }
+result.groups.year   // "2026"
+```
+
+### 5.2 `@@replace` 中的具名反向引用
+
+```js
+// 交换年月日顺序
+"2026-04-01".replace(
+  /(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})/u,
+  "$<day>.$<month>.$<year>"
+)
+// "01.04.2026"
+```
+
+### 5.3 具名反向引用 `\k<name>`
+
+在模式内部引用具名组（Named Backreference）：
+
+```js
+// 匹配带引号的字符串（单引号或双引号）
+/(?<quote>["'])(?<content>.*?)\k<quote>/.exec('"hello"')
+// ["\"hello\"", '"', 'hello', index: 0, ...]
+```
+
+### 5.4 浏览器兼容性
+
+| 特性 | Chrome | Firefox | Safari | Edge |
+|---|---|---|---|---|
+| `(?<name>...)` 具名捕获组 | 64+ | 78+ | 11.1+ | 79+ |
+| `groups` 属性 | 64+ | 78+ | 11.1+ | 79+ |
+| `\k<name>` 具名反向引用 | 64+ | 78+ | 11.1+ | 79+ |
+| `$<name>` 替换占位符 | 64+ | 78+ | 11.1+ | 79+ |
+
+> **来源**：MDN & Can I Use。IE 全系不支持。移动端 iOS Safari 11.1+、Android Chrome 64+ 均已支持。
+
+---
+
+## 6. `RegExp.prototype[@@match]` 内部槽协议
+
+### 6.1 Symbol 作为内部方法
+
+ECMAScript 规范使用 **Well-Known Symbols** 表示内部方法的钩子：
+
+```js
+RegExp.prototype[Symbol.match]    // 规范定义的内部 [[Match]] 方法
+RegExp.prototype[Symbol.replace]  // 规范定义的内部 [[Replace]] 方法
+RegExp.prototype[Symbol.search]   // 规范定义的内部 [[Search]] 方法
+RegExp.prototype[Symbol.split]    // 规范定义的内部 [[Split]] 方法
+RegExp.prototype[Symbol.matchAll]  // 规范定义的内部 [[MatchAll]] 方法
+```
+
+### 6.2 Symbol 方法的意义
+
+1. **子类化**：可以继承 `RegExp` 并覆盖这些 Symbol 方法改变匹配行为
+2. **身份标识**：`Symbol.match` 属性用于判断对象是否"像正则"
+3. **正则化对象**：让非 RegExp 对象也能参与正则协议
+
+```js
+// 自定义一个"正则化"对象
+const obj = {
+  [Symbol.match](str) {
+    return str.includes("foo") ? ["foo"] : null;
+  }
+};
+"hello-foo-world".match(obj)  // ["foo"]
+```
+
+### 6.3 `@@matchAll` 与 Match Iterator
+
+ES2020 引入 `Symbol.matchAll`，返回 **Match Iterator**：
+
+```js
+const re = /(\w)-(\d)/g;
+const str = "a-1 b-2 c-3";
+for (const match of str.matchAll(re)) {
+  console.log(match[0], match[1], match[2], match.groups);
+}
+// "a-1" "a" "1" { undefined, undefined }
+// (无命名组则 groups 为 undefined)
+```
+
+> 注意：`matchAll` 要求正则必须带 `g` flag，否则抛出 `TypeError`。
+
+---
+
+## 7. 浏览器的 RegExp 兼容性（Can I Use）
+
+以下为主要 RegExp 特性的浏览器支持情况：
+
+| 特性 | Chrome | Firefox | Safari | Edge | IE |
+|---|---|---|---|---|---|
+| 基本 RegExp | ✅ 1+ | ✅ 1+ | ✅ 1+ | ✅ 12+ | ✅ 5.5+ |
+| `lastIndex`（g/y）| ✅ 39+ | ✅ 25+ | ✅ 8+ | ✅ 12+ | ❌ |
+| `u` flag | ✅ 50+ | ✅ 29+ | ✅ 10+ | ✅ 79+ | ❌ |
+| `s` flag (dotAll) | ✅ 62+ | ✅ 78+ | ✅ 11.1+ | ✅ 79+ | ❌ |
+| 具名捕获组 | ✅ 64+ | ✅ 78+ | ✅ 11.1+ | ✅ 79+ | ❌ |
+| 断言 `(?<=)` `(?<!)` | ✅ 62+ | ✅ 78+ | ✅ 11.1+ | ✅ 79+ | ❌ |
+| `v` flag (ES2024) | ✅ 122+ | ✅ 127+ | ✅ 17.4+ | ✅ 122+ | ❌ |
+| `\p{...}` Unicode 属性 | ✅ 64+ | ✅ 78+ | ✅ 11.1+ | ✅ 79+ | ❌ |
+| `d` flag (indices) | ✅ 126+ | ✅ 126+ | ✅ 16.4+ | ✅ 126+ | ❌ |
+
+> `d` flag：ES2022 引入，给匹配结果添加 `indices` 数组，表示每个捕获组在原字符串中的起始/结束位置。
+
+---
+
+## 8. 实际应用：从 W3C 角度理解
+
+### 8.1 URL 正则的陷阱
+
+解析 URL 时，按 W3C URL 规范（WHATWG URL Standard），正则处理需要考虑：
+
+```js
+// ❌ 常见错误：假设 URL 只有一个"."或不含 Unicode
+// /https?:\/\/[^\/]+/.test("https://example.com/") 
+
+// ✅ 正确处理 Unicode 域名和路径
+const URL_REGEX = /^(?<protocol>https?):\/\/(?<host>[\w.-]+)(?<path>\/.*)?$/u;
+
+// ✅ 匹配百分号编码的 Unicode
+/%[0-9A-Fa-f]{2}/.test("https://example.com/%E4%B8%AD%E6%96%87")
+```
+
+**W3C 角度**：URL 的合法字符集在 WHATWG URL Standard 中定义，正则只是验证工具。真正的 URL 解析应使用 `new URL()` API，而非纯正则。
+
+### 8.2 HTML 标签匹配
+
+```js
+// 匹配自闭合标签（SVG、MathML 等）
+const SELF_CLOSING_TAG = /<([a-z][a-z0-9-]*)\s*([^>]*)\/?>/gi;
+
+// 匹配带命名空间的标签
+const NS_TAG = /<([a-zA-Z][a-zA-Z0-9]*):([a-zA-Z][a-zA-Z0-9]*)\s*([^>]*)>/gi;
+
+// 匹配 HTML 注释（条件注释不适用）
+const COMMENT = /<!--[\s\S]*?-->/g;
+```
+
+> **规范注意**：HTML 规范中的标签名必须遵循 [HTML5 标签名规则](https://html.spec.whatwg.org/multipage/syntax.html#syntax-tag-name)，正则只能做近似验证。
+
+### 8.3 CSS 选择器转正则（简化）
+
+很多场景需要将 CSS 选择器转为正则进行 DOM 查询：
+
+```js
+/**
+ * 将简单 CSS 选择器转为正则（支持 class、id、属性选择器）
+ * 仅用于理解原理，实际应使用 DOM API（querySelector）
+ */
+function cssToRegex(selector) {
+  let pattern = selector
+    // 转义正则特殊字符
+    .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    // class 选择器 .foo → 匹配 class 属性中的 foo
+    .replace(/\.([a-zA-Z_-]+)/g, '(?:.*\\s)?$1(?:\\s|$)')
+    // id 选择器 #foo
+    .replace(/#([a-zA-Z_-]+)/g, '(?:id=["\']?)$1(?:["\']?\\s|$)');
+
+  return new RegExp(`^${pattern}`, 'i');
+}
+
+cssToRegex('.card')    // /^ (?:.*\s)?card(?:\s|$) /i
+cssToRegex('#header')  // /^ (?:id=["\']?)header(?:["\']?\s|$) /i
+```
+
+### 8.4 表单验证（实际业务场景）
+
+```js
+// 符合 W3C HTML5 验证规范的输入模式
+const patterns = {
+  // 邮箱（简化版，真实场景用 type="email"）
+  email: /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zZ0-9-]{0,61}[a-zA-Z0-9])?)*$/,
+
+  // URL（简化版）
+  url: /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/,
+
+  // 中国手机号（宽松匹配）
+  phoneCN: /^(?:\+86)?1[3-9]\d{9}$/,
+
+  // IPv4 地址
+  ipv4: /^(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)$/,
+};
+```
+
+---
+
+## 9. `RegExp.prototype.exec()` 规范算法要点
+
+规范 §21.2.2.2（`RegExpBuiltinExec`）定义了 `exec()` 的标准行为：
+
+1. **初始化**：`lastIndex` 从 `this.lastIndex` 读取
+2. **位置校验**：如果 `lastIndex > str.length`，执行失败，重置 `lastIndex` → `0`，返回 `null`
+3. **匹配尝试**：从 `lastIndex` 位置开始尝试模式匹配
+4. **Sticky 检查**：若 `sticky` flag 存在且匹配位置 ≠ `lastIndex`，返回 `null`
+5. **结果记录**：匹配成功后记录 `startIndex`、`endIndex`，并填充捕获组
+6. **推进**：`lastIndex` 设为 `endIndex`
+7. **空匹配处理**：若匹配长度为 0，推进 1 个字符单位（见 §4.5 规则）
+
+```js
+// 演示空匹配推进行为
+const re = /a?/g;      // 匹配 "a" 或 空串
+const r = /a?/gu;      // 同上，但空匹配按代码点推进
+"abc".match(re)        // ["a", "", "b", "", "c", ""] — 6 个结果
+```
+
+---
+
+## 10. 参考资料
+
+- [ECMAScript 规范 - RegExp Objects (tc39.es/ecma262)](https://tc39.es/ecma262/#sec-regexp-regular-expression-objects)
+- [MDN - RegExp](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp)
+- [MDN - RegExp Unicode mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode)
+- [MDN - RegExp Sticky flag](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/sticky)
+- [MDN - Named capturing group](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Named_capturing_group)
+- [Can I Use - RegExp lastIndex](https://caniuse.com/mdn-javascript_builtins_regexp_lastindex)
+- [Can I Use - RegExp unicode](https://caniuse.com/mdn-javascript_builtins_regexp_unicode)
+- [WHATWG URL Standard](https://url.spec.whatwg.org/)
+- [HTML Standard - Tag name](https://html.spec.whatwg.org/multipage/syntax.html#syntax-tag-name)

--- a/docs/js/regex-in-browser/examples/index.html
+++ b/docs/js/regex-in-browser/examples/index.html
@@ -1,0 +1,667 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>JS RegExp W3C 标准视角 — 交互演示</title>
+  <style>
+    :root {
+      --bg: #1a1a2e;
+      --surface: #16213e;
+      --border: #0f3460;
+      --accent: #e94560;
+      --accent2: #533483;
+      --text: #eaeaea;
+      --muted: #a0a0a0;
+      --green: #4ecca3;
+      --yellow: #ffd369;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: 'Segoe UI', system-ui, sans-serif;
+      line-height: 1.6;
+      padding: 2rem;
+      min-height: 100vh;
+    }
+
+    h1 {
+      font-size: 1.5rem;
+      color: var(--accent);
+      margin-bottom: 0.25rem;
+    }
+    .subtitle { color: var(--muted); font-size: 0.875rem; margin-bottom: 1.5rem; }
+
+    .section {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 1.25rem;
+      margin-bottom: 1.25rem;
+    }
+
+    .section h2 {
+      font-size: 1rem;
+      color: var(--green);
+      margin-bottom: 0.75rem;
+      border-left: 3px solid var(--green);
+      padding-left: 0.5rem;
+    }
+
+    .controls {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 0.75rem;
+      margin-bottom: 0.75rem;
+    }
+
+    label {
+      font-size: 0.8rem;
+      color: var(--muted);
+      display: block;
+      margin-bottom: 0.2rem;
+    }
+
+    input[type="text"],
+    input[type="number"],
+    textarea,
+    select {
+      width: 100%;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      color: var(--text);
+      font-family: 'Fira Code', 'Cascadia Code', monospace;
+      font-size: 0.875rem;
+      padding: 0.4rem 0.6rem;
+      outline: none;
+      transition: border-color 0.2s;
+    }
+    input[type="text"]:focus,
+    textarea:focus { border-color: var(--accent); }
+
+    textarea { resize: vertical; min-height: 60px; }
+
+    .flags-row {
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+      align-items: center;
+    }
+
+    .flag-btn {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      color: var(--muted);
+      font-family: monospace;
+      font-size: 0.875rem;
+      padding: 0.25rem 0.6rem;
+      cursor: pointer;
+      transition: all 0.2s;
+      user-select: none;
+    }
+    .flag-btn.active {
+      background: var(--accent2);
+      border-color: var(--accent);
+      color: #fff;
+    }
+    .flag-btn:hover { border-color: var(--accent); }
+
+    button.run-btn {
+      background: var(--accent);
+      color: #fff;
+      border: none;
+      border-radius: 4px;
+      padding: 0.5rem 1.25rem;
+      font-size: 0.875rem;
+      cursor: pointer;
+      margin-top: 0.5rem;
+      transition: opacity 0.2s;
+    }
+    button.run-btn:hover { opacity: 0.85; }
+
+    .output {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 0.75rem;
+      font-family: 'Fira Code', monospace;
+      font-size: 0.8rem;
+      min-height: 60px;
+      white-space: pre-wrap;
+      word-break: break-all;
+      max-height: 300px;
+      overflow-y: auto;
+    }
+
+    .match-highlight { color: var(--green); font-weight: bold; }
+    .group-highlight { color: var(--yellow); }
+    .null-result { color: var(--accent); }
+    .index-info { color: var(--muted); font-size: 0.75rem; margin-top: 0.25rem; }
+
+    .demo-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+      gap: 1rem;
+    }
+
+    .preset-card {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 0.75rem;
+      cursor: pointer;
+      transition: border-color 0.2s;
+    }
+    .preset-card:hover { border-color: var(--accent); }
+    .preset-card .title { color: var(--green); font-size: 0.875rem; font-weight: bold; }
+    .preset-card .desc { color: var(--muted); font-size: 0.75rem; margin-top: 0.25rem; }
+
+    .info-box {
+      background: rgba(78, 204, 163, 0.08);
+      border: 1px solid rgba(78, 204, 163, 0.3);
+      border-radius: 4px;
+      padding: 0.75rem;
+      font-size: 0.8rem;
+      color: var(--green);
+      margin-top: 0.5rem;
+    }
+
+    .lastindex-demo {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 0.75rem;
+      margin-top: 0.75rem;
+    }
+
+    @media (max-width: 640px) {
+      .controls { grid-template-columns: 1fr; }
+      .lastindex-demo { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+
+<h1>JS RegExp W3C 标准视角 — 交互演示</h1>
+<p class="subtitle">ECMAScript 规范 Symbol 方法 · Unicode 模式 · lastIndex 机制 · 具名捕获组</p>
+
+<!-- ========== 基础演示 ========== -->
+<div class="section">
+  <h2>1. 基础匹配（String.prototype.match / exec）</h2>
+
+  <div class="controls">
+    <div>
+      <label>Pattern</label>
+      <input type="text" id="pattern" value="[a-z]+" placeholder="e.g. [a-z]+" />
+    </div>
+    <div>
+      <label>Test String</label>
+      <input type="text" id="testStr" value="Hello World 123" placeholder="string to test" />
+    </div>
+  </div>
+
+  <label>Flags</label>
+  <div class="flags-row" style="margin: 0.5rem 0 0.75rem;">
+    <button class="flag-btn active" data-flag="g">g</button>
+    <button class="flag-btn" data-flag="i">i</button>
+    <button class="flag-btn" data-flag="m">m</button>
+    <button class="flag-btn" data-flag="s">s</button>
+    <button class="flag-btn" data-flag="u">u</button>
+    <button class="flag-btn" data-flag="y">y</button>
+    <button class="flag-btn" data-flag="d">d</button>
+    <span style="color:var(--muted);font-size:0.75rem;margin-left:0.5rem" id="flags-display">g</span>
+  </div>
+
+  <button class="run-btn" id="runBasic">运行 match()</button>
+
+  <div class="output" id="basicOutput">点击运行查看结果...</div>
+  <p class="index-info" id="basicInfo"></p>
+</div>
+
+<!-- ========== Unicode 演示 ========== -->
+<div class="section">
+  <h2>2. Unicode 模式（u flag）— 代码点 vs 代码单元</h2>
+
+  <div class="controls">
+    <div>
+      <label>Pattern（. 匹配任意字符）</label>
+      <input type="text" id="unicodePattern" value="." placeholder="." />
+    </div>
+    <div>
+      <label>Test String（含 Emoji / 汉字）</label>
+      <input type="text" id="unicodeStr" value="Hello😄世界𝟙𝟚𝟛" />
+    </div>
+  </div>
+
+  <div class="flags-row" style="margin-bottom:0.75rem;">
+    <button class="flag-btn" data-group="unicode" data-flag="g">g</button>
+    <button class="flag-btn active" data-group="unicode" data-flag="u">u</button>
+    <span style="color:var(--muted);font-size:0.75rem;margin-left:0.5rem" id="unicodeFlags">u</span>
+  </div>
+
+  <button class="run-btn" id="runUnicode">运行 match()</button>
+
+  <div class="output" id="unicodeOutput">点击运行查看结果...</div>
+  <div class="info-box" id="unicodeInfo">
+    注意：JS 字符串使用 UTF-16 编码。<br>
+    无 <code>u</code> flag：<code>.</code> 匹配 1 个代码单元（surrogate half 匹配失败）<br>
+    有 <code>u</code> flag：<code>.</code> 匹配 1 个 Unicode 代码点
+  </div>
+</div>
+
+<!-- ========== lastIndex 演示 ========== -->
+<div class="section">
+  <h2>3. lastIndex — g flag 循环 vs y flag 粘滞</h2>
+
+  <div class="controls">
+    <div>
+      <label>Pattern</label>
+      <input type="text" id="lastIndexPattern" value="\w+" />
+    </div>
+    <div>
+      <label>Test String</label>
+      <input type="text" id="lastIndexStr" value="apple banana apple" />
+    </div>
+    <div>
+      <label>Initial lastIndex</label>
+      <input type="number" id="lastIndexVal" value="0" min="0" />
+    </div>
+  </div>
+
+  <div class="flags-row" style="margin-bottom:0.75rem;">
+    <button class="flag-btn active" data-group="lastIndex" data-flag="g">g</button>
+    <button class="flag-btn" data-group="lastIndex" data-flag="y">y</button>
+    <button class="flag-btn" data-group="lastIndex" data-flag="gy">g + y</button>
+    <span style="color:var(--muted);font-size:0.75rem;margin-left:0.5rem" id="lastIndexFlags">g</span>
+  </div>
+
+  <button class="run-btn" id="runLastIndex">运行 exec()</button>
+
+  <div class="output" id="lastIndexOutput">点击运行查看结果...</div>
+  <div class="info-box" id="lastIndexInfo">
+    <code>g</code>：循环匹配所有结果，自动推进 lastIndex<br>
+    <code>y</code>：严格从 lastIndex 开始匹配，不向前扫描<br>
+    <code>g + y</code>：sticky 优先，只从 lastIndex 开始（不循环）
+  </div>
+</div>
+
+<!-- ========== 具名捕获组 ========== -->
+<div class="section">
+  <h2>4. 具名捕获组（Named Capture Groups）</h2>
+
+  <div class="controls">
+    <div>
+      <label>Pattern（含具名组）</label>
+      <input type="text" id="namedPattern" value='(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})' />
+    </div>
+    <div>
+      <label>Test String</label>
+      <input type="text" id="namedStr" value="2026-04-01 and 2025-12-31" />
+    </div>
+  </div>
+
+  <div class="flags-row" style="margin-bottom:0.75rem;">
+    <button class="flag-btn active" data-group="named" data-flag="g">g</button>
+    <button class="flag-btn active" data-group="named" data-flag="u">u</button>
+    <span style="color:var(--muted);font-size:0.75rem;margin-left:0.5rem" id="namedFlags">gu</span>
+  </div>
+
+  <button class="run-btn" id="runNamed">运行 match()</button>
+
+  <div class="output" id="namedOutput">点击运行查看结果...</div>
+  <div class="info-box">
+    <code>result.groups</code> — 具名捕获组对象（ES2018+）<br>
+    <code>$&lt;name&gt;</code> — replace 中的具名占位符
+  </div>
+</div>
+
+<!-- ========== @@replace 演示 ========== -->
+<div class="section">
+  <h2>5. String.prototype.replace — Symbol.replace 协议</h2>
+
+  <div class="controls">
+    <div>
+      <label>Search Pattern</label>
+      <input type="text" id="replacePattern" value="(\w+)\s(\w+)" />
+    </div>
+    <div>
+      <label>Replacement</label>
+      <input type="text" id="replaceWith" value="$2 $1" placeholder="$2 $1 or $<name>" />
+    </div>
+    <div>
+      <label>Input String</label>
+      <input type="text" id="replaceStr" value="Hello World" />
+    </div>
+  </div>
+
+  <div class="flags-row" style="margin-bottom:0.75rem;">
+    <button class="flag-btn active" data-group="replace" data-flag="g">g</button>
+    <button class="flag-btn" data-group="replace" data-flag="u">u</button>
+    <span style="color:var:var(--muted);font-size:0.75rem;margin-left:0.5rem" id="replaceFlags">g</span>
+  </div>
+
+  <button class="run-btn" id="runReplace">运行 replace()</button>
+
+  <div class="output" id="replaceOutput">点击运行查看结果...</div>
+</div>
+
+<!-- ========== Symbol.matchAll ========== -->
+<div class="section">
+  <h2>6. Symbol.matchAll — Match Iterator</h2>
+
+  <div class="controls">
+    <div>
+      <label>Pattern</label>
+      <input type="text" id="matchAllPattern" value="(\d+)-(\w+)" />
+    </div>
+    <div>
+      <label>Test String</label>
+      <input type="text" id="matchAllStr" value="1-a 2-b 3-c" />
+    </div>
+  </div>
+
+  <div class="flags-row" style="margin-bottom:0.75rem;">
+    <button class="flag-btn active" data-group="matchAll" data-flag="g">g</button>
+    <button class="flag-btn" data-group="matchAll" data-flag="u">u</button>
+    <span style="color:var(--muted);font-size:0.75rem;margin-left:0.5rem" id="matchAllFlags">g</span>
+  </div>
+
+  <button class="run-btn" id="runMatchAll">运行 matchAll()</button>
+
+  <div class="output" id="matchAllOutput">点击运行查看结果...</div>
+  <div class="info-box">
+    <code>matchAll()</code> 返回可迭代对象，每次迭代产出完整 Match 对象（含 indices、groups）
+  </div>
+</div>
+
+<!-- ========== 预设快捷演示 ========== -->
+<div class="section">
+  <h2>7. 预设快捷演示</h2>
+  <div class="demo-grid">
+    <div class="preset-card" onclick="runPreset('url')">
+      <div class="title">URL 验证</div>
+      <div class="desc">演示带 u flag 的 URL 正则匹配</div>
+    </div>
+    <div class="preset-card" onclick="runPreset('unicodeProp')">
+      <div class="title">Unicode 属性</div>
+      <div class="desc">\p{L} 匹配汉字、拉丁字母等</div>
+    </div>
+    <div class="preset-card" onclick="runPreset('lookaround')">
+      <div class="title">零宽断言</div>
+      <div class="desc">(?=) (?!) (?&lt;=) (?&lt;!) 位置匹配</div>
+    </div>
+    <div class="preset-card" onclick="runPreset('emptyMatch')">
+      <div class="title">空匹配推进</div>
+      <div class="desc">演示 lastIndex 在空匹配时的推进行为</div>
+    </div>
+  </div>
+  <div class="output" id="presetOutput" style="margin-top:0.75rem">选择一个预设查看效果...</div>
+</div>
+
+<script>
+  // ─── 全局状态 ───
+  const state = {
+    basic: { flags: new Set(['g']) },
+    unicode: { flags: new Set(['u', 'g']) },
+    lastIndex: { flags: new Set(['g']) },
+    named: { flags: new Set(['g', 'u']) },
+    replace: { flags: new Set(['g']) },
+    matchAll: { flags: new Set(['g']) },
+  };
+
+  // ─── Flag 按钮交互 ───
+  document.querySelectorAll('.flag-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const group = btn.dataset.group;
+      const flag = btn.dataset.flag;
+
+      if (group) {
+        // 多选模式
+        const groupFlags = state[group].flags;
+        if (groupFlags.has(flag)) {
+          groupFlags.delete(flag);
+          btn.classList.remove('active');
+        } else {
+          groupFlags.add(flag);
+          btn.classList.add('active');
+        }
+        document.getElementById(`${group}Flags`).textContent = [...groupFlags].join('');
+      } else {
+        // 单选模式（基础）
+        if (state.basic.flags.has(flag)) {
+          state.basic.flags.delete(flag);
+          btn.classList.remove('active');
+        } else {
+          state.basic.flags.add(flag);
+          btn.classList.add('active');
+        }
+        document.getElementById('flags_display').textContent = [...state.basic.flags].join('');
+      }
+    });
+  });
+
+  // ─── 基础匹配 ───
+  document.getElementById('runBasic').addEventListener('click', () => {
+    const pattern = document.getElementById('pattern').value;
+    const str = document.getElementById('testStr').value;
+    const flags = [...state.basic.flags].join('');
+    runMatch(pattern, str, flags, 'basicOutput', 'basicInfo');
+  });
+
+  // ─── Unicode ───
+  document.getElementById('runUnicode').addEventListener('click', () => {
+    const pattern = document.getElementById('unicodePattern').value;
+    const str = document.getElementById('unicodeStr').value;
+    const flags = [...state.unicode.flags].join('');
+    runMatch(pattern, str, flags, 'unicodeOutput');
+    showUnicodeInfo(str, flags);
+  });
+
+  // ─── lastIndex ───
+  document.getElementById('runLastIndex').addEventListener('click', () => {
+    const pattern = document.getElementById('lastIndexPattern').value;
+    const str = document.getElementById('lastIndexStr').value;
+    const flags = [...state.lastIndex.flags].join('');
+    const startLastIndex = parseInt(document.getElementById('lastIndexVal').value, 10) || 0;
+    runExecLoop(pattern, str, flags, startLastIndex, 'lastIndexOutput');
+  });
+
+  // ─── 具名捕获 ───
+  document.getElementById('runNamed').addEventListener('click', () => {
+    const pattern = document.getElementById('namedPattern').value;
+    const str = document.getElementById('namedStr').value;
+    const flags = [...state.named.flags].join('');
+    runMatch(pattern, str, flags, 'namedOutput');
+  });
+
+  // ─── replace ───
+  document.getElementById('runReplace').addEventListener('click', () => {
+    const pattern = document.getElementById('replacePattern').value;
+    const replacement = document.getElementById('replaceWith').value;
+    const str = document.getElementById('replaceStr').value;
+    const flags = [...state.replace.flags].join('');
+    try {
+      const re = new RegExp(pattern, flags);
+      const result = str.replace(re, replacement);
+      document.getElementById('replaceOutput').innerHTML =
+        `<span class="group-highlight">Input:</span> ${escapeHtml(str)}\n` +
+        `<span class="group-highlight">Replacement:</span> ${escapeHtml(replacement)}\n` +
+        `<span class="group-highlight">Result:</span> <span class="match-highlight">${escapeHtml(result)}</span>`;
+    } catch (e) {
+      document.getElementById('replaceOutput').innerHTML =
+        `<span class="null-result">Error: ${escapeHtml(e.message)}</span>`;
+    }
+  });
+
+  // ─── matchAll ───
+  document.getElementById('runMatchAll').addEventListener('click', () => {
+    const pattern = document.getElementById('matchAllPattern').value;
+    const str = document.getElementById('matchAllStr').value;
+    const flags = [...state.matchAll.flags].join('');
+    try {
+      const re = new RegExp(pattern, flags);
+      const results = [...str.matchAll(re)];
+      const lines = results.map((m, i) => {
+        const groups = m.groups ? JSON.stringify(m.groups) : 'undefined';
+        return `[${i}] ${formatMatch(m)} | groups: ${groups}`;
+      });
+      document.getElementById('matchAllOutput').innerHTML =
+        results.length
+          ? lines.join('\n')
+          : `<span class="null-result">null — 无匹配或正则缺少 g flag</span>`;
+    } catch (e) {
+      document.getElementById('matchAllOutput').innerHTML =
+        `<span class="null-result">Error: ${escapeHtml(e.message)}</span>`;
+    }
+  });
+
+  // ─── 预设演示 ───
+  const PRESETS = {
+    url: () => {
+      const re = /^(?<protocol>https?):\/\/(?<host>[\w.-]+)(?<path>\/.*)?$/u;
+      const tests = [
+        'https://example.com/path',
+        'http://test.cn/api/v1',
+        'not-a-url',
+        'ftp://files.server.com'
+      ];
+      return tests.map(s => {
+        const m = re.exec(s);
+        return m ? `✓ ${s}\n  → protocol: ${m.groups.protocol}, host: ${m.groups.host}, path: ${m.groups.path}`
+                  : `✗ ${s}`;
+      }).join('\n\n');
+    },
+    unicodeProp: () => {
+      const re = /\p{L}/gu;
+      const tests = ['Hello世界ABC日本語', 'Θεός και ἄνθρωπος', '🎉 emoji & symbols'];
+      return tests.map(s => {
+        const matches = s.match(re);
+        return `Input: ${s}\nMatches (\\p{L}): ${matches ? matches.join(', ') : 'null'}`;
+      }).join('\n\n');
+    },
+    lookaround: () => {
+      const str = 'foo123bar456baz789';
+      const results = [
+        { label: '(?=\\d+) — 数字前位置', pattern: /(?=\d+)/g },
+        { label: '(?!\\d) — 非数字后位置', pattern: /(?!\d)/g },
+        { label: '(?<=\\d{3}) — 数字三连后位置', pattern: /(?<=\d{3})/g },
+        { label: '(?<!foo)bar — 非 foo 后 bar', pattern: /(?<!foo)bar/g },
+      ];
+      return results.map(r => {
+        const re = new RegExp(r.pattern.source, 'g');
+        const matches = [...str.matchAll(re)];
+        return `Pattern: /${r.pattern.source}/g\n  Label: ${r.label}\n  String: ${str}\n  Matches at indices: ${matches.map(m => m.index).join(', ')}`;
+      }).join('\n\n');
+    },
+    emptyMatch: () => {
+      const re = /a?/gu;
+      const str = 'abc';
+      const matches = str.match(re);
+      const info = [];
+      let li = 0;
+      for (const m of matches) {
+        const re2 = new RegExp(re.source, re.flags);
+        re2.lastIndex = li;
+        const r = re2.exec(str);
+        info.push(`match "${m}" at index ${r.index}, lastIndex → ${re2.lastIndex}`);
+        li = re2.lastIndex || li + 1;
+      }
+      return `Pattern: /a?/gu  String: "${str}"\nResults: ${matches.join(', ')}\n\n${info.join('\n')}`;
+    },
+  };
+
+  function runPreset(name) {
+    const output = document.getElementById('presetOutput');
+    try {
+      output.textContent = PRESETS[name]();
+    } catch (e) {
+      output.textContent = `Error: ${e.message}`;
+    }
+  }
+
+  // ─── 辅助函数 ───
+  function runMatch(pattern, str, flags, outputId) {
+    const out = document.getElementById(outputId);
+    try {
+      const re = new RegExp(pattern, flags);
+      const result = str.match(re);
+      if (result === null) {
+        out.innerHTML = `<span class="null-result">null — 无匹配</span>`;
+      } else {
+        const lines = Array.isArray(result)
+          ? result.map((m, i) => `[${i}] ${formatMatch(m)}`).join('\n')
+          : formatMatch(result);
+        out.innerHTML = `<span class="match-highlight">${escapeHtml(lines)}</span>`;
+      }
+    } catch (e) {
+      out.innerHTML = `<span class="null-result">SyntaxError: ${escapeHtml(e.message)}</span>`;
+    }
+  }
+
+  function runExecLoop(pattern, str, flags, startLastIndex, outputId) {
+    const out = document.getElementById(outputId);
+    try {
+      const re = new RegExp(pattern, flags);
+      re.lastIndex = startLastIndex;
+      const lines = [];
+      let step = 0;
+      let result;
+      while ((result = re.exec(str)) !== null && step < 20) {
+        lines.push(
+          `[Step ${step}] lastIndex=${re.lastIndex - result[0].length}→${re.lastIndex}  ` +
+          `match="${result[0]}"  index=${result.index}` +
+          (result.groups ? `  groups=${JSON.stringify(result.groups)}` : '')
+        );
+        step++;
+      }
+      if (lines.length === 0) {
+        out.innerHTML = `<span class="null-result">null — lastIndex=${startLastIndex} 处无匹配</span>`;
+      } else {
+        out.textContent = lines.join('\n');
+      }
+    } catch (e) {
+      out.innerHTML = `<span class="null-result">Error: ${escapeHtml(e.message)}</span>`;
+    }
+  }
+
+  function formatMatch(m) {
+    if (m === null) return 'null';
+    const parts = [escapeHtml(m[0])];
+    if (m.index !== undefined) parts.push(`index=${m.index}`);
+    if (m.groups) parts.push(`groups=${JSON.stringify(m.groups)}`);
+    if (m.indices) parts.push(`indices=${JSON.stringify(m.indices)}`);
+    return parts.join(' | ');
+  }
+
+  function escapeHtml(str) {
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+  }
+
+  function showUnicodeInfo(str, flags) {
+    const info = document.getElementById('unicodeInfo');
+    const hasU = flags.includes('u');
+    const charDetails = [...str].map(ch => {
+      const codePoint = ch.codePointAt(0).toString(16).toUpperCase();
+      const isEmoji = ch.length > 1;
+      return `${ch} (U+${codePoint.padStart(4,'0')})${isEmoji ? ' [emoji, 2 code units]' : ''}`;
+    });
+    info.innerHTML = `
+      <strong>字符串分析：</strong>${str}<br>
+      <strong>字符拆解（按代码点）：</strong><br>
+      &nbsp;&nbsp;${charDetails.join(' | ')}<br><br>
+      <strong>匹配粒度：</strong>${hasU ? '按 Unicode 代码点' : '按 UTF-16 代码单元'}<br>
+      <strong>无 u 时：</strong><code>.</code> 不匹配 surrogate half（0xD83D 等）<br>
+      <strong>有 u 时：</strong><code>.</code> 正确匹配整个代码点
+    `;
+  }
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## 变更内容

### 新增文档：docs/js/regex-in-browser.md
从 ECMAScript 规范角度深入梳理 JavaScript 正则表达式：

- RegExp 规范定义（内部槽、字面量解析）
- String.prototype Symbol 方法协议（@@match/@@replace/@@search/@@split/@@matchAll）
- Unicode 模式（u flag）与 UTF-16 代码点
- lastIndex / sticky(y) / global(g) 机制
- 具名捕获组（NFE）浏览器兼容性
- 浏览器 RegExp 兼容性表（Can I Use）
- 实际应用（URL 正则、HTML 标签、CSS 选择器转正则）

### 新增交互演示：docs/js/regex-in-browser/examples/index.html
包含 7 个交互模块，覆盖 match/exec、Unicode 模式对比、lastIndex 机制、具名捕获组、Symbol.matchAll、预设快捷演示。